### PR TITLE
updated requirements and turned off debug

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -334,4 +334,4 @@ def update_display(n_clicks, jsonified_data, subspecies, view, sex, hybrid, num_
                     style = {'color': 'MidnightBlue'})
 
 if __name__ == '__main__':
-    app.run_server(debug=True)
+    app.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pandas==2.0.0
-plotly==5.14.1
-dash==2.9.3
+pandas==2.0.3
+plotly==5.15.0
+dash==2.11.1


### PR DESCRIPTION
Updated requirements to most recent versions of `pandas`, `plotly`, and `dash`. 

Turned off debug mode and set `app.run` in place of `app.run_server`, as suggested in Issue #42.