### PR TITLE
Fix lat/long display in hover-text

### DIFF
--- a/components/graphs.py
+++ b/components/graphs.py
@@ -64,8 +64,8 @@ def make_map(df, color_by):
                         title = "Distribution of Samples")
     
     fig.update_traces(hovertemplate = 
-                        "Latitude: %{Lat}<br>"+
-                        "Longitude: %{Lon}<br>" +
+                        "Latitude: %{lat}<br>"+
+                        "Longitude: %{lon}<br>" +
                         "Samples at lat/lon: %{customdata[0]}<br>" +
                         "Species at lat/lon: %{customdata[1]}<br>" +
                         "Subspecies at lat/lon: %{customdata[2]}<br>"


### PR DESCRIPTION
Hovertext in map view was displaying `{Lat}` and `{Lon}` instead of the actual latitude and longitude:
![Screenshot 2023-09-05 at 3 51 43 PM](https://github.com/Imageomics/dashboard-prototype/assets/38985481/5c4e26f3-1c5c-405c-96cd-eb0b16cd191e)
This bug was introduced with the capitalization change in [this commit](https://github.com/Imageomics/dashboard-prototype/pull/51/commits/3dc2e5a5af312af0915c3c99714068a2d57c5219#diff-cb557dda40bed1e7e34041919e7b3b819f08f9a266572b5de2445c48b93dba7b).
It is now fixed to display properly as shown below.
![Screenshot 2023-09-05 at 3 52 14 PM](https://github.com/Imageomics/dashboard-prototype/assets/38985481/4ddd00d5-e468-4702-bc7c-77c26273500a)
