### PR TITLE
Set max image width to 400px for display to avoid overfill.

### DIFF
--- a/components/query.py
+++ b/components/query.py
@@ -4,6 +4,7 @@ from dash import html
 # Helper functions for Dashboard
 
 PRINT_STYLE = {"color": "MidnightBlue"}
+MAX_IMG_SIZE = "400px"
 
 def get_data(df, mapping, features):
     '''
@@ -124,7 +125,7 @@ def get_images(df, subspecies, view, sex, hybrid, num_images):
                 image_path = filepaths[i] + filenames[i]
             else:
                 image_path = filepaths[i] + '/' + filenames[i]
-        Imgs.append(html.Img(src = image_path))
+        Imgs.append(html.Img(src = image_path, style = {"max-width": MAX_IMG_SIZE}))
     return Imgs
 
 def get_filenames(df, subspecies, view, sex, hybrid, num_images):

--- a/components/query.py
+++ b/components/query.py
@@ -4,7 +4,7 @@ from dash import html
 # Helper functions for Dashboard
 
 PRINT_STYLE = {"color": "MidnightBlue"}
-MAX_IMG_SIZE = "400px"
+IMG_STYLE = {"max-width": "400px"}
 
 def get_data(df, mapping, features):
     '''
@@ -125,7 +125,7 @@ def get_images(df, subspecies, view, sex, hybrid, num_images):
                 image_path = filepaths[i] + filenames[i]
             else:
                 image_path = filepaths[i] + '/' + filenames[i]
-        Imgs.append(html.Img(src = image_path, style = {"max-width": MAX_IMG_SIZE}))
+        Imgs.append(html.Img(src = image_path, style = IMG_STYLE))
     return Imgs
 
 def get_filenames(df, subspecies, view, sex, hybrid, num_images):


### PR DESCRIPTION
Sets the maximum image width to 400px so that multiple images can be displayed in a row without overfilling the screen. This does not have a visible impact on our current test sets, but was noticed with other data routinely used by the institute.