### PR TITLE
Standardize function descriptions

### DIFF
--- a/components/divs.py
+++ b/components/divs.py
@@ -29,7 +29,7 @@ DOCS_LINK = html.A("documentation",
 
 def get_hist_div(mapping):
     '''
-    Function to generate the histogram options section of the dashboard, including button to select 'Map View'. 
+    Generates the histogram options section of the dashboard, including button to select 'Map View'. 
     Provides choice of variables for distribution and to color by, with options for order to sort x-axis.
 
     Parameters:
@@ -93,7 +93,7 @@ def get_hist_div(mapping):
 
 def get_map_div():
     '''
-    Function to generate the mapping options section of the dashboard. 
+    Generates the mapping options section of the dashboard. 
     Provides choice of variables to color by and button to switch back to histogram ('Show Histogram').
 
     Returns:
@@ -152,8 +152,8 @@ def get_map_div():
 
 def get_img_div(df, all_species, img_url):
     '''
-    Function to generate the Image Sampling options section of the dashboard, including button to display images. 
-    Provides empty list if no URLS are provided in the DataFrame for the entries.
+    Generates the Image Sampling options section of the dashboard, including button to display images. 
+    Provides empty list if no URLs are provided in the DataFrame for the entries.
 
     Parameters:
     -----------
@@ -241,7 +241,7 @@ def get_img_div(df, all_species, img_url):
 
 def get_main_div(hist_div, img_div):
     '''
-    Function to return main div based on upload of data.
+    Returns main div based on upload of data.
 
     Parameters:
     -----------
@@ -299,7 +299,7 @@ def get_main_div(hist_div, img_div):
 
 def get_error_div(error_dict):
     '''
-    Function to return appropriate error message if there's a problem uploading the selected file.
+    Returns appropriate error message if there's a problem uploading the selected file.
 
     Parameters:
     -----------

--- a/components/query.py
+++ b/components/query.py
@@ -8,7 +8,7 @@ IMG_STYLE = {"max-width": "400px"}
 
 def get_data(df, mapping, features):
     '''
-    Function to read in DataFrame and perform required manipulations: 
+    Reads in DataFrame and performs required manipulations: 
         - fill null values in required columns with 'unknown'
         - add 'lat-lon', `Samples_at_locality`, 'Species_at_locality', and 'Subspecies_at_locality' columns.
         - make list of categorical columns.
@@ -68,7 +68,7 @@ def get_data(df, mapping, features):
 
 def get_species_options(df):
     '''
-    Function to pull in DataFrame and produce a dictionary of species options (Melpomene, Erato, and Any)
+    Pulls in DataFrame and produces a dictionary of species options (Melpomene, Erato, and Any)
 
     Parameters:
     -----------
@@ -94,7 +94,7 @@ def get_species_options(df):
 
 def get_images(df, subspecies, view, sex, hybrid, num_images):
     '''
-    Function to retrieve the user-selected number of images.
+    Retrieves the user-selected number of images.
 
     Parameters:
     -----------

--- a/dashboard.py
+++ b/dashboard.py
@@ -55,7 +55,7 @@ app.layout = html.Div([
 
 def parse_contents(contents, filename):
     '''
-    Function to read uploaded data.
+    Reads uploaded data, checks that it meets requirements, and processes it. Returns processed data and available options in JSON.
     '''
     if contents is None:
         raise PreventUpdate
@@ -150,7 +150,7 @@ def update_output(contents, filename):
 
 def get_visuals(jsonified_data):
     '''
-    Function that usese the processed and saved data to get the main div (histogram, pie chart, and image example options).
+    Fetches the main div (histogram, pie chart, and image example options) based on the processed and saved data.
     Returns error div if error occurs in upload or essential features are missing.
     '''
     # load saved data
@@ -177,7 +177,7 @@ def get_visuals(jsonified_data):
 
 def update_dist_view(n_clicks, children, jsonified_data):
     '''
-    Function to update the upper left distribution options based on selected distribution chart (histogram or map).
+    Updates the upper left distribution options based on selected distribution chart (histogram or map).
     Activates on click to change, defaults to histogram view.
 
     Parameters:
@@ -217,7 +217,7 @@ def update_dist_view(n_clicks, children, jsonified_data):
 
 def update_dist_plot(x_var, color_by, sort_by, btn, jsonified_data):
     '''
-    Function to update distribution figure with either map or histogram based on selections.
+    Updates distribution figure with either map or histogram based on selections.
     Selection is based on current label of the button ('Map View' or 'Show Histogram'), which updates prior to graph.
 
     Parameters:
@@ -281,7 +281,7 @@ def update_pie_plot(var, jsonified_data):
 
 def set_subspecies_options(selected_species, jsonified_data):
     ''' 
-    Function to set subspecies options in dropdown based on user-selected species.
+    Sets subspecies options in dropdown based on user-selected species.
 
     Parameters:
     -----------
@@ -321,7 +321,7 @@ def set_subspecies_value(available_options):
 # Retrieve selected number of images
 def update_display(n_clicks, jsonified_data, subspecies, view, sex, hybrid, num_images):
     '''
-    Function to retrieve the user-selected number of images adhering to their chosen parameters when the 'Display Images' button is pressed.
+    Retrieves the user-selected number of images adhering to their chosen parameters when the 'Display Images' button is pressed.
     
     Parameters:
     -----------


### PR DESCRIPTION
As noted in PR #62 [discussion](https://github.com/Imageomics/dashboard-prototype/pull/62#discussion_r1583345498), there's a bit of redundancy in function descriptions across a few files ("Function to ..."). This removes those so function descriptions are consistently active.