### PR TITLE
Fix bug in dropdown for image selector (Issue #63)

### DIFF
--- a/components/query.py
+++ b/components/query.py
@@ -68,7 +68,7 @@ def get_data(df, mapping, features):
 
 def get_species_options(df):
     '''
-    Pulls in DataFrame and produces a dictionary of species options (Melpomene, Erato, and Any)
+    Pulls in DataFrame and produces a dictionary of species options (eg., melpomene, erato, and Any)
 
     Parameters:
     -----------
@@ -79,13 +79,13 @@ def get_species_options(df):
     all_species - Dictionary of all potential species options and their subspecies.
 
     '''
-    species_list = list(df.Species.unique())
+    species_list = list(df.Species.dropna().unique()) # drop nulls to avoid adding non-species (or subspecies below)
     all_species = {}
     for species in species_list:
-        subspecies_list = df.loc[df.Species == species, 'Subspecies'].unique()
-        subspecies_list = np.insert(subspecies_list, 0 , 'Any-' + species.capitalize())
-        all_species[species.capitalize()] = list(subspecies_list)
-    all_subspecies = np.insert(df.Subspecies.unique(), 0, 'Any')
+        subspecies_list = df.loc[df.Species == species, 'Subspecies'].dropna().unique()
+        subspecies_list = np.insert(subspecies_list, 0 , 'Any-' + species) # need this to match as filled for img selection
+        all_species[species] = list(subspecies_list)
+    all_subspecies = np.insert(df.Subspecies.dropna().unique(), 0, 'Any')
     all_species['Any'] = list(all_subspecies)
     
     return all_species
@@ -139,11 +139,13 @@ def get_filenames(df, subspecies, view, sex, hybrid, num_images):
     filepaths - List of filepaths (URLs) corresponding to the selected filenames. 
     
     '''
-    if 'Any' in subspecies and type(subspecies) == str:
+    if ('Any' in subspecies and type(subspecies) == str) or ('Any' in subspecies[0] and len(subspecies) == 1):
+        if type(subspecies) == list:
+            subspecies = subspecies[0]
         if subspecies == 'Any':
             df_sub = df.copy()
         else:
-            species = subspecies.split('-')[1].lower()
+            species = subspecies.split('-')[1] # should match case as filled
             df_sub = df.loc[df.Species == species].copy()
     else:
         df_sub = df.loc[df.Subspecies.isin(subspecies)].copy()

--- a/dashboard.py
+++ b/dashboard.py
@@ -116,10 +116,10 @@ def parse_contents(contents, filename):
 
     # get dataset-determined static data:
         # the dataframe and categorical features - processed for map view if mapping is True
-        # all possible species, subspecies
+        # all possible species, subspecies -- must run first to avoid adding "unknown" to lists
         # will likely include categorical options in later instance (sooner)
+    all_species = get_species_options(df)
     processed_df, cat_list = get_data(df, mapping, included_features)
-    all_species = get_species_options(processed_df)
     # save data to dictionary to save as json 
     data = {
             'processed_df': processed_df.to_json(date_format = 'iso', orient = 'split'),

--- a/tests/components/test_query.py
+++ b/tests/components/test_query.py
@@ -7,15 +7,15 @@ from components.query import get_species_options, get_data, get_filenames, get_i
 class TestQuery(unittest.TestCase):
     def test_get_species_options(self):
         data = {
-            'Species': ['melpomene', 'erato', 'metharme'],
+            'Species': ['Melpomene', 'erato', 'metharme'],
             'Subspecies': ['subspecies1', 'subspecies2', 'subspecies3']
         }
         df = pd.DataFrame(data=data)
         result = get_species_options(df)
-        self.assertEqual(result.keys(), set(["Melpomene", "Erato", "Metharme", "Any"]))
+        self.assertEqual(result.keys(), set(["Melpomene", "erato", "metharme", "Any"]))
         self.assertEqual(result["Melpomene"], ['Any-Melpomene', 'subspecies1'])
-        self.assertEqual(result["Erato"],['Any-Erato', 'subspecies2'])
-        self.assertEqual(result["Metharme"], ['Any-Metharme', 'subspecies3'])
+        self.assertEqual(result["erato"],['Any-erato', 'subspecies2'])
+        self.assertEqual(result["metharme"], ['Any-metharme', 'subspecies3'])
         self.assertEqual(result["Any"],
                          ['Any', 'subspecies1', 'subspecies2', 'subspecies3'])
     
@@ -75,9 +75,9 @@ class TestQuery(unittest.TestCase):
                         'unknown']
         }
         df = pd.DataFrame(data = data)
-        test_subspecies = ['Any-Melpomene', 
+        test_subspecies = ['Any-melpomene', 
                            ['guarica'], 
-                           'Any-Erato',
+                           'Any-erato',
                            'Any', 
                            ['schunkei', 'nanna', 'rosina_N']
                            ]


### PR DESCRIPTION
Resolves Issue #63, using Option 1 described in [this comment](https://github.com/Imageomics/dashboard-prototype/issues/63#issuecomment-2083723502) to avoid the instances of `unknown` for the subspecies calling up multiple different species images. In addition to being viewable as described there, their existence and relative prevalence is evident in the distribution graphs, so I think this is sufficient for now.